### PR TITLE
펫 수정 뷰, 펫 품종 리스트 뷰 생성

### DIFF
--- a/petweb/account/apis/api_pet.py
+++ b/petweb/account/apis/api_pet.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from utils import pagination, pet_age, \
     permissions as custom_permissions
 from ..models import Pet, PetSpecies, PetBreed
-from ..serializers import PetSerializer, PetCreateSerializer, UserSerializer, PetEditSerializer
+from ..serializers import *
 
 User = get_user_model()
 
@@ -16,6 +16,7 @@ __all__ = (
     'PetListCreate',
     'PetAge',
     'PetProfile',
+    'PetBreedList',
 )
 
 
@@ -243,3 +244,23 @@ class PetProfile(generics.RetrieveUpdateDestroyAPIView):
             'pet': serializer.data
         }
         return Response(data)
+
+
+class PetBreedList(generics.GenericAPIView):
+    serializer_class = PetBreedSerializer
+
+    def get_queryset(self):
+        if self.request.data['species'] == 'dog':
+            return PetBreed.dogs.all()
+        elif self.request.data['species'] == 'cat':
+            return PetBreed.cats.all()
+
+    def post(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        if queryset is None:
+            error_message = {
+                "detail": "Invalid or none value."
+            }
+            return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/petweb/account/apis/api_pet.py
+++ b/petweb/account/apis/api_pet.py
@@ -246,21 +246,31 @@ class PetProfile(generics.RetrieveUpdateDestroyAPIView):
         return Response(data)
 
 
+# 펫 품종 리스트 보기 뷰
 class PetBreedList(generics.GenericAPIView):
     serializer_class = PetBreedSerializer
 
     def get_queryset(self):
+        # species 입력 값이 dog 라면
         if self.request.data['species'] == 'dog':
+            # 강아지로 필터링된 쿼리셋을 가져온다
             return PetBreed.dogs.all()
+        # 입력 값이 cat 이라면
         elif self.request.data['species'] == 'cat':
+            # 고양이로 필터링된 쿼리셋을 가져온다
             return PetBreed.cats.all()
 
+    # method: post
     def post(self, request, *args, **kwargs):
+        # 쿼리셋을 불러온다
         queryset = self.filter_queryset(self.get_queryset())
+        # 만일 쿼리셋이 비어 있다면 (species 입력이 잘못되었을 경우)
         if queryset is None:
+            # 에러 메시지를 보낸다
             error_message = {
                 "detail": "Invalid or none value."
             }
             return Response(error_message, status=status.HTTP_400_BAD_REQUEST)
+        # 이상 없다면 시리얼라이저를 만든다
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/petweb/account/models/model_pet.py
+++ b/petweb/account/models/model_pet.py
@@ -12,6 +12,7 @@ __all__ = (
 )
 
 
+# 펫 종류 (고양이/강아지) 모델
 class PetSpecies(models.Model):
     # 강아지, 고양이 품종을 고른다 (다른 동물 추가 가능)
     CHOICE_TYPE = (
@@ -31,28 +32,41 @@ class PetSpecies(models.Model):
         verbose_name_plural = "Pet species"
 
 
+# 펫 품종 중 강아지 쿼리셋 매니저
+# https://docs.djangoproject.com/en/1.11/topics/db/managers/#modifying-a-manager-s-initial-queryset
 class DogManager(models.Manager):
+    # 쿼리셋 호출 함수
     def get_queryset(self):
+        # 펫 품종 모델의 쿼리셋에서 pet_type이 'dog'인 객체들만 리턴
         return super(DogManager, self).get_queryset().filter(
             species=PetSpecies.objects.get(pet_type='dog')
         )
 
 
+# 펫 품종 중 고양이 쿼리셋 매니저
 class CatManager(models.Manager):
+    # 쿼리셋 호출 함수
     def get_queryset(self):
+        # 펫 품종 모델의 쿼리셋에서 pet_type이 'cat'인 객체들만 리턴
         return super(CatManager, self).get_queryset().filter(
             species=PetSpecies.objects.get(pet_type='cat')
         )
 
 
+# 펫 품종 모델
 class PetBreed(models.Model):
+    # 펫 종류
     species = models.ForeignKey(
         PetSpecies
     )
+    # 품종 이름
     breeds_name = models.CharField(max_length=50)
 
+    # 커스텀 매니저가 생겼기 때문에 원래 모델 매니저가 상속됨을 명시해 준다
     objects = models.Manager()
+    # DogManager는 'dogs' attribute로 정의
     dogs = DogManager()
+    # CatManager는 'cats' attribute로 정의
     cats = CatManager()
 
     USERNAME_FIELD = 'breeds_name'
@@ -61,6 +75,7 @@ class PetBreed(models.Model):
         return self.breeds_name
 
 
+# 펫 모델
 class Pet(models.Model):
     # 동물의 주인
     owner = models.ForeignKey(

--- a/petweb/account/models/model_pet.py
+++ b/petweb/account/models/model_pet.py
@@ -31,25 +31,34 @@ class PetSpecies(models.Model):
         verbose_name_plural = "Pet species"
 
 
+class DogManager(models.Manager):
+    def get_queryset(self):
+        return super(DogManager, self).get_queryset().filter(
+            species=PetSpecies.objects.get(pet_type='dog')
+        )
+
+
+class CatManager(models.Manager):
+    def get_queryset(self):
+        return super(CatManager, self).get_queryset().filter(
+            species=PetSpecies.objects.get(pet_type='cat')
+        )
+
+
 class PetBreed(models.Model):
     species = models.ForeignKey(
         PetSpecies
     )
     breeds_name = models.CharField(max_length=50)
 
+    objects = models.Manager()
+    dogs = DogManager()
+    cats = CatManager()
+
     USERNAME_FIELD = 'breeds_name'
 
     def __str__(self):
         return self.breeds_name
-
-#
-# # 참고
-# # https://docs.djangoproject.com/ko/1.11/topics/db/managers/#calling-custom-queryset-methods-from-the-manager
-# class PetQuerySet(models.QuerySet):
-#     def dogs(self):
-#         return self.filter()
-#
-#
 
 
 class Pet(models.Model):

--- a/petweb/account/serializers/serializer_pet.py
+++ b/petweb/account/serializers/serializer_pet.py
@@ -17,6 +17,7 @@ __all__ = (
     'PetSerializer',
     'PetCreateSerializer',
     'PetEditSerializer',
+    'PetBreedSerializer',
 )
 
 
@@ -173,6 +174,7 @@ class PetCreateSerializer(serializers.ModelSerializer):
         return data
 
 
+# 펫 정보를 수정하는 시리얼라이저
 class PetEditSerializer(serializers.ModelSerializer):
     name = serializers.CharField(max_length=100)  # 이름
     # http://www.django-rest-framework.org/api-guide/fields/#datefield
@@ -269,3 +271,14 @@ class PetEditSerializer(serializers.ModelSerializer):
         instance.save()
 
         return instance
+
+
+class PetBreedSerializer(serializers.ModelSerializer):
+    species = PetSpeciesField(write_only=True)
+
+    class Meta:
+        model = PetBreed
+        fields = (
+            'species',
+            'breeds_name',
+        )

--- a/petweb/account/serializers/serializer_pet.py
+++ b/petweb/account/serializers/serializer_pet.py
@@ -1,6 +1,9 @@
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
+from rest_framework.serializers import raise_errors_on_nested_writes
 from rest_framework.settings import api_settings
+from rest_framework.utils import model_meta
 
 from ..relations import MultiplePKsHyperlinkedIdentityField
 from ..models import Pet, PetSpecies, PetBreed
@@ -9,15 +12,17 @@ from . import UserSerializer
 User = get_user_model()
 
 __all__ = (
-    'PetSpeciesSerializer',
-    'PetBreedSerializer',
+    'PetSpeciesField',
+    'PetBreedField',
     'PetSerializer',
     'PetCreateSerializer',
+    'PetEditSerializer',
 )
 
 
-# 펫 종류 시리얼라이저
-class PetSpeciesSerializer(serializers.ModelSerializer):
+# 펫 종류 관계 필드
+class PetSpeciesField(serializers.RelatedField):
+    queryset = PetSpecies.objects.all()
 
     class Meta:
         model = PetSpecies
@@ -27,9 +32,30 @@ class PetSpeciesSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         return instance.get_pet_type_display()
 
+    # 입력 형식을 커스텀
+    def to_internal_value(self, data):
+        try:
+            try:
+                # dog/cat을 입력하면 거기에 맞는 인스턴스를 출력해준다
+                return PetSpecies.objects.get(pet_type=data)
+            # 예외 처리들
+            except KeyError:
+                raise serializers.ValidationError(
+                    'data is a required field.'
+                )
+            except ValueError:
+                raise serializers.ValidationError(
+                    'data must be an "dog" or "cat".'
+                )
+        except ObjectDoesNotExist:
+            raise serializers.ValidationError(
+                'data does not exist.'
+            )
 
-# 펫 품종 시리얼라이저
-class PetBreedSerializer(serializers.ModelSerializer):
+
+# 펫 품종 관계 필드
+class PetBreedField(serializers.RelatedField):
+    queryset = PetBreed.objects.all()
 
     class Meta:
         model = PetBreed
@@ -39,13 +65,33 @@ class PetBreedSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         return instance.breeds_name
 
+    # 입력 형식을 커스텀
+    def to_internal_value(self, data):
+        try:
+            try:
+                # dog/cat을 입력하면 거기에 맞는 인스턴스를 출력해준다
+                return PetBreed.objects.get(breeds_name=data)
+            # 예외 처리들
+            except KeyError:
+                raise serializers.ValidationError(
+                    'data is a required field.'
+                )
+            except ValueError:
+                raise serializers.ValidationError(
+                    'data must be an PetBreeds Objects.'
+                )
+        except ObjectDoesNotExist:
+            raise serializers.ValidationError(
+                'data does not exist.'
+            )
+
 
 # 펫의 내용을 보여주는 시리얼라이저
 class PetSerializer(serializers.ModelSerializer):
     # 펫 종류는 PetSpeciesSerializer로 가공된다
-    species = PetSpeciesSerializer()
+    species = PetSpeciesField()
     # 펫 품종은 PetBreedSerializer로 가공된다
-    breeds = PetBreedSerializer()
+    breeds = PetBreedField()
     # 펫 나이는 PetAge 뷰를 URL 값으로 보여주도록 설계
     # 여러 개의 키워드 인자 값을 받기 위해 필드를 커스텀
     ages = MultiplePKsHyperlinkedIdentityField(
@@ -80,6 +126,10 @@ class PetCreateSerializer(serializers.ModelSerializer):
     name = serializers.CharField(max_length=100)  # 이름
     # http://www.django-rest-framework.org/api-guide/fields/#datefield
     birth_date = serializers.DateField(format=api_settings.DATE_FORMAT)  # 생년월일
+    # RelatedField의 to_interval_value를 이용해 입력값을 제어
+    # 참고: https://goo.gl/roNmog
+    species = PetSpeciesField()  # 강아지/고양이
+    breeds = PetBreedField()  # 품종
     # http://www.django-rest-framework.org/api-guide/fields/#choicefield
     gender = serializers.ChoiceField(choices=Pet.CHOICE_GENDER)  # 성별
     body_color = serializers.ChoiceField(choices=Pet.CHOICE_COLOR)  # 색상
@@ -121,3 +171,101 @@ class PetCreateSerializer(serializers.ModelSerializer):
         }
 
         return data
+
+
+class PetEditSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(max_length=100)  # 이름
+    # http://www.django-rest-framework.org/api-guide/fields/#datefield
+    birth_date = serializers.DateField(format=api_settings.DATE_FORMAT)  # 생년월일
+    # RelatedField의 to_interval_value를 이용해 입력값을 제어
+    # 참고: https://goo.gl/roNmog
+    species = PetSpeciesField()  # 강아지/고양이
+    breeds = PetBreedField()  # 품종
+    # http://www.django-rest-framework.org/api-guide/fields/#choicefield
+    gender = serializers.ChoiceField(choices=Pet.CHOICE_GENDER)  # 성별
+    body_color = serializers.ChoiceField(choices=Pet.CHOICE_COLOR)  # 색상
+    identified_number = serializers.CharField(max_length=20)  # 동물등록번호
+    is_neutering = serializers.BooleanField()  # 중성화
+    is_active = serializers.BooleanField()  # 활성화
+    ages = MultiplePKsHyperlinkedIdentityField(
+        view_name='profile:pet-age',
+        lookup_fields=['owner_id', 'pk'],
+        lookup_url_kwargs=['user_pk', 'pet_pk']
+    )  # 나이
+
+    class Meta:
+        model = Pet
+        fields = (
+            'pk',  # 동물pk
+            'species',  # 강아지/고양이
+            'breeds',  # 품종
+            'name',  # 이름
+            'birth_date',  # 생년월일
+            'gender',  # 성별
+            'body_color',  # 색깔
+            'identified_number',  # 동물등록번호
+            'is_neutering',  # 중성화
+            'is_active',  # 활성화여부(동물사망/양도/입양)
+            'ages',
+        )
+        read_only_fields = (
+            'pk',
+            'ages',
+        )
+
+    # 출력 형식을 커스터마이징
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        data = {
+            'owner': UserSerializer(instance.owner).data,
+            'pet': ret
+        }
+
+        return data
+
+    # 입력 형식을 커스터마이징
+    def to_internal_value(self, data):
+        # 입력한 데이터(dict 형식)를 key와 value로 나누어 순회한다
+        result = {}
+        for key, value in data.items():
+            # 만일 value가 없다면, 즉 사용자가 변경 사항을 아무것도 입력하지 않았다면
+            if not value:
+                # 원래 객체가 가지고 있던 값을 입력한다
+                result[key] = getattr(self.instance, f'{key}')
+            else:
+                # 만일 변경 사항이 있다면 그 값을 입력한다
+                result[key] = value
+
+        return result
+
+    def update(self, instance, validated_data):
+        # 원래 update 메소드를 긁어와서 커스텀
+        raise_errors_on_nested_writes('update', self, validated_data)
+        info = model_meta.get_field_info(instance)
+
+        # validated_data를 키와 값으로 나누어 순회한다
+        for attr, value in validated_data.items():
+            # 만일 attr 값이 species고 value의 type이 문자열이라면
+            # 즉, 사용자가 값을 바꾸려고 한다면
+            if attr == 'species' and type(value) == str:
+                # 사용자가 바꾸려고 하는 값의 펫 종류 객체를 가져온다
+                pet_species_instance = PetSpecies.objects.get(pet_type=value)
+                # 펫 인스턴스의 species 값을 새로운 펫 종류 객체로 교체한다
+                # https://docs.python.org/3/library/functions.html#setattr
+                setattr(instance, attr, pet_species_instance)
+            # 만일 attr 값이 breeds고 value의 type이 문자열이라면
+            elif attr == 'breeds' and type(value) == str:
+                # 사용자가 바꾸려고 하는 값의 펫 품종 객체를 가져온다
+                pet_breed_instance = PetBreed.objects.get(breeds_name=value)
+                # 펫 인스턴스의 breeds 값을 새로운 펫 품종 객체로 교체한다
+                setattr(instance, attr, pet_breed_instance)
+            # 나머지는 update 원래 메소드 가져옴
+            elif attr in info.relations and info.relations[attr].to_many:
+                # https://docs.python.org/3/library/functions.html#getattr
+                field = getattr(instance, attr)
+                field.set(value)
+            else:
+                setattr(instance, attr, value)
+        instance.save()
+
+        return instance

--- a/petweb/account/serializers/serializer_pet.py
+++ b/petweb/account/serializers/serializer_pet.py
@@ -240,6 +240,7 @@ class PetEditSerializer(serializers.ModelSerializer):
 
         return result
 
+    # 업데이트 메소드 커스터마이징
     def update(self, instance, validated_data):
         # 원래 update 메소드를 긁어와서 커스텀
         raise_errors_on_nested_writes('update', self, validated_data)
@@ -273,6 +274,7 @@ class PetEditSerializer(serializers.ModelSerializer):
         return instance
 
 
+# 사용자가 강아지/고양이를 선택하면 펫 품종을 보여주는 시리얼라이저
 class PetBreedSerializer(serializers.ModelSerializer):
     species = PetSpeciesField(write_only=True)
 

--- a/petweb/account/tests/test_pet.py
+++ b/petweb/account/tests/test_pet.py
@@ -86,8 +86,8 @@ class PetCreateListTest(APILiveServerTestCase):
             'birth_date': '2014-04-15',
             'gender': 'male',
             'body_color': 'gold',
-            'species': '1',
-            'breeds': '1',
+            'species': 'dog',
+            'breeds': '시츄',
             'identified_number': '1234',
             'is_neutering': 'true',
         }

--- a/petweb/account/urls/url_profile.py
+++ b/petweb/account/urls/url_profile.py
@@ -8,6 +8,8 @@ urlpatterns = [
 ]
 
 urlpatterns += [
+    # 펫 품종 뷰
+    url(r'^pet-breed-list/$', apis.PetBreedList.as_view(), name='pet-breed-list'),
     # 펫 리스트 / 펫 생성
     url(r'^(?P<user_pk>\d+)/pets/$', apis.PetListCreate.as_view(), name='pets'),
     # 펫 디테일 뷰


### PR DESCRIPTION
1. 펫 수정 뷰 생성
  - API 뷰 생성
  - PetEditSerializer 생성
    (species, breeds를 수정할 경우 입력값을 instance가 아닌 str으로 인식하는 이슈 발생.
    이를 해결하기 위해 시리얼라이저의 update 메소드를 커스터마이징)
2. 펫 품종 리스트 생성
  - 펫 품종의 커스텀 매니저 생성
    (강아지, 고양이에 해당하는 품종 쿼리셋을 입맛따라 불러올 수 있도록)
  - API 뷰 생성
  - PetBreedSerializer 생성
